### PR TITLE
[#9] Use servant-generic

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - containers
 - bcrypt
 - servant
+- servant-generic
 - servant-server
 - jwt
 - random

--- a/src/Lib/Server.hs
+++ b/src/Lib/Server.hs
@@ -5,6 +5,7 @@ module Lib.Server
        , server
        ) where
 
+import Servant.Generic (toServant)
 import Servant.Server (Handler, Server, hoistServer)
 
 import Lib.App (App, AppEnv, runAppAsHandler)
@@ -13,4 +14,4 @@ import Lib.Server.Auth (AuthAPI, authServer)
 type API = AuthAPI
 
 server :: AppEnv -> Server API
-server env = hoistServer (Proxy @API) (runAppAsHandler env) authServer
+server env = hoistServer (Proxy @API) (runAppAsHandler env) (toServant authServer)

--- a/three-layer.cabal
+++ b/three-layer.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 225865dcfad49c71df181dad7b2ff0d1deebf4df61e17474afd07b4e57708672
+-- hash: 9209b203f601892af0869150e2b1b5d5f495509deef983f2c56acba968b6a462
 
 name:           three-layer
 version:        0.1.0.0
@@ -43,6 +43,7 @@ library
     , random
     , resource-pool
     , servant
+    , servant-generic
     , servant-server
     , time
     , universum
@@ -87,6 +88,7 @@ executable three-layer-exe
     , random
     , resource-pool
     , servant
+    , servant-generic
     , servant-server
     , three-layer
     , time
@@ -121,6 +123,7 @@ test-suite three-layer-test
     , random
     , resource-pool
     , servant
+    , servant-generic
     , servant-server
     , tasty
     , tasty-discover


### PR DESCRIPTION
This PR introduces `servant-generic` library. It replaces single big alias with record data type. It's considered to be more convenient, and type errors should be better.

Resolves #9 